### PR TITLE
Added JSON rendering using express' built-in method

### DIFF
--- a/src/BaseController.js
+++ b/src/BaseController.js
@@ -58,6 +58,6 @@ module.exports = Class(function (req, res, next) {
       })
     }
   , json: function(data, headers, status){
-      this.response.json(data, headers, status);
+      this.response.json(data, headers, status)
     }
   })


### PR DESCRIPTION
Noticed there was no way to output JSON through the controller and simply mirrored Express.  If you would like this done in some other way, feel free to discard. I would love to be able to create views which render JSON instead of simply rendering JSON in the controller.
