### PR TITLE
Handle case where Express' default view options are undefined

### DIFF
--- a/src/BaseController.js
+++ b/src/BaseController.js
@@ -7,7 +7,7 @@ module.exports = Class(function (req, res, next) {
   this._viewFolder = ''
 
   var viewOptions = app.set('view options')
-  this.layout = (viewOptions && undefined !== typeof viewOptions.layout) ? viewOptions.layout : 'layout'
+  this.layout = (viewOptions && 'undefined' !== typeof viewOptions.layout) ? viewOptions.layout : 'layout'
 
   this.beforeFilters = []
   this.excludeFilters = []


### PR DESCRIPTION
When attempting to get the basic "Hello World" app running from `matador init` I received an exception related to Express:

```
TypeError: Cannot read property 'layout' of undefined
    at fn.<anonymous> (/Users/VanMacbook/Projects/matador-test/node_modules/matador/src/BaseController.js:9:39)
```

The return value from 'view options' was undefined (not an empty object), so calling 'layout' on it resulted in an an exception being thrown.  This was likely a result of the recent PR #16.  Just wanted to fix this so others could get up and running with a quick "Hello World" app.
