### PR TITLE
Add next callback to arguments passed to the controller

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -16,7 +16,7 @@ function match(app, prefix, method, route, middleware, controllerName, action) {
   }
 
   app[method](route, middleware, function (req, res, next) {
-    Controller[action].apply(Controller, [req, res].concat(v(req.params).values()))
+    Controller[action].apply(Controller, [req, res].concat(v(req.params).values().concat(next)))
   })
 }
 


### PR DESCRIPTION
I like the way matador is providing a simpler method to req.params for controllers, but leaving off the next callback is problematic. Specifically I've had problems when integrating with Passport for authentication which expects the next to be there for passing on errors.

I debated on including this right after [req, res] which would make it identical to Express, however I went with adding it as the final arg simply because I think the req.params will be used more often and the next arg isn't always required.
