### PR TITLE
Added explicit way for adding a new module path in matador

### DIFF
--- a/src/matador.js
+++ b/src/matador.js
@@ -92,6 +92,10 @@ module.exports.createApp = function (baseDir, configuration, options) {
     Base: require('./BaseController')(app)
   }
 
+  app.addModulePath = function (dir) {
+    appDirs.push(dir)
+  }
+
   app.mount = function () {
     var router = require('./router')
       , self = this
@@ -195,8 +199,6 @@ module.exports.createApp = function (baseDir, configuration, options) {
 
   return app
 }
-
-
 
 module.exports.engine = {
   compile: function (source, options) {


### PR DESCRIPTION
Allowing matador users to add explicit module paths in addition to the default locations (app/ and app/modules/MODULE_NAME)
