### PR TITLE
Fixing infinte loop in matador startup on Windows

### DIFF
--- a/src/matador.js
+++ b/src/matador.js
@@ -45,7 +45,7 @@ module.exports.createApp = function (baseDir, configuration, options) {
   configuration = configuration || {}
   options = options || {}
 
-  var appDir = baseDir + '/app'
+  var appDir = path.join(baseDir, '/app')
     , fileCache = {'services': {}, 'helpers': {}, 'models': {}, 'controllers': {}}
     , objCache = {'services': {}, 'helpers': {}, 'models': {}, 'controllers': {}}
     , pathCache = {'services': {}, 'helpers': {}, 'models': {}, 'controllers': {}}


### PR DESCRIPTION
Using string concats for working with OS paths is dangerous, because *nix uses forwardslashes and Windows
backslashes. This cause runung in infinte loop on app.getPartials function in "while (viewDir != rootDir)" comprassion. So better use nodeJS path.join function everywhere. I've fix this place, but similar error can be elsewhere 
