### PR TITLE
Add Node 0.8.x Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       , "url": "https://github.com/Obvious/matador.git"
     }
   , "engines": {
-      "node": ">=0.6.0 <0.7.0"
+      "node": ">=0.6.0 <0.8.x"
     }
   , "bin": {
       "matador": "bin/matador.js"


### PR DESCRIPTION
I've updated `package.json` to allow Node 0.8.x. From what I can tell there are no tests in Matador. Are there any spots that we know will break if we upgrade? From what I can tell after looking at the source, it's ok.
