### PR TITLE
Fixing node 0.8.1 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       , "url": "https://github.com/Obvious/matador.git"
     }
   , "engines": {
-      "node": ">=0.6.0 <0.8.x"
+      "node": ">=0.6.0 <=0.8.x"
     }
   , "bin": {
       "matador": "bin/matador.js"


### PR DESCRIPTION
Looks like I missed the `=` sign in `package.json` which prevented the new version of node from being used. Sorry about that.
