### PR TITLE
node 0.8.1 fixed, verified

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       , "url": "https://github.com/Obvious/matador.git"
     }
   , "engines": {
-      "node": ">=0.6.0 <=0.8.x"
+      "node": ">=0.6.0 <0.9"
     }
   , "bin": {
       "matador": "bin/matador.js"


### PR DESCRIPTION
Turns out `<0.9` was the best way to get the whole `0.8.x` series working. Tested locally with `npm install -g`. Sorry about the hassle.
