### PR TITLE
Make CacheHelper validation more flexible with PUT and DELETEs

### DIFF
--- a/src/helpers/CacheHelper.js
+++ b/src/helpers/CacheHelper.js
@@ -157,8 +157,9 @@ module.exports = function (app) {
       return true
     }
 
-    // Allow responses to POST, but only if the response isn't explicitly public.
-    if (req.method == 'POST' && !cacheControl['public']) {
+    // Allow responses to POST/PUT/DELETE, but only if the response isn't explicitly public.
+    // See section 13.10 of RFC2616.
+    if (!cacheControl['public'] && (req.method == 'POST' || req.method == 'PUT' || req.method == 'DELETE')) {
       return true
     }
 


### PR DESCRIPTION
Hello sho, 

Please review the following commits I made in branch 'cache'.

20e84801822314ea733fa97c035f6ede63cf82e7 (24 seconds ago)
Make CacheHelper validation more flexible with PUT and DELETEs

R=sho
