### PR TITLE
Makes path matcher handle wildcard params as an array

### DIFF
--- a/src/matador.js
+++ b/src/matador.js
@@ -342,7 +342,12 @@ module.exports.createApp = function (baseDir, configuration, options) {
       req.params = {}
       if (handler.matches) {
         for (var key in handler.matches) {
-          req.params[key] = decodeURI(handler.matches[key])
+          if (key == '*' && Array.isArray(handler.matches['*'])) {
+            // The wildcard param passes an array of path parts.
+            req.params['*'] = handler.matches['*'].map(decodeURI)
+          } else {
+            req.params[key] = decodeURI(handler.matches[key])
+          }
         }
       }
       return next()


### PR DESCRIPTION
Hello jeremy, 

Please review the following commits I made in branch 'cache'.

a2ceb28df62416f75fb6ea2de16ae58701d6568f (16 seconds ago)
Makes matador handle wildcard params properly

R=jeremy
