### PR TITLE
New method for controllers - renderXML()

### DIFF
--- a/src/BaseController.js
+++ b/src/BaseController.js
@@ -81,6 +81,32 @@ module.exports = function (app) {
           throw e
         }
       }
+
+    , renderXML: function (res, view, data, fn, opt_injectedData) {
+        data = data || {}
+
+        var prefix = view.substring(0, view.indexOf(':'))
+        if (prefix == 'soy') {
+          var output = renderClosureTemplate(
+              view.substring(4), data, this.layout, opt_injectedData)
+          return fn ? fn(output) : res.send(output)
+        }
+
+        var viewFile = findViewFile(this._paths, view)
+
+        // Start looking for partials in the same directory as the view file.
+        var partialsDir = path.resolve(viewFile, '../')
+
+        try {
+          return res.render(viewFile, {
+              locals: data
+            , partials: app.getPartials(partialsDir)
+            }, fn)
+        } catch (e) {
+          console.error('Rendering error, view:', viewFile, 'error:', e.message, e.stack)
+          throw e
+        }
+      }
     })
 
   /**


### PR DESCRIPTION
The existing render() method works fine for standard page requests, but generating a page via views/layout.html is not useful for AJAX requests.  To allow my server code to use Mustache within XML reponses, I made an alternate method, renderXML().  This method is nearly identical to the existing method render(), but it does not specify a layout file.  The resulting HTML structure contains only the HTML snippet from the file named in the method call.
