### PR TITLE
Add support for POST requests

### DIFF
--- a/src/all/server.js
+++ b/src/all/server.js
@@ -23,6 +23,8 @@ app.configure(function () {
   // TODO: Add JSON body parser middleware
   app.use(app.requestDecorator())
   app.use(app.preRouter())
+
+  app.use(matador.bodyParser())
 })
 
 app.configure('development', function () {


### PR DESCRIPTION
Use connect's bodyParser middleware to give controller methods access to the POST contents.
