### PR TITLE
Test to make sure regexp matchers work

### DIFF
--- a/src/pathMatcher.js
+++ b/src/pathMatcher.js
@@ -135,7 +135,7 @@ PathMatcher.prototype.getMatch = function(path) {
 
   // If we stopped at a node but it doesn't have an object associated with it
   // then fallback to an open wildcard node.
-  if (!node.object && pendingWildcard) {
+  if (!node || !node.object && pendingWildcard) {
     node = pendingWildcard
   }
 

--- a/tests/PathMatcher_test.js
+++ b/tests/PathMatcher_test.js
@@ -49,6 +49,9 @@ exports.testRegExpPathMatching = function(test) {
   pm.add('/@re2:aaa|bbb', 'regexp2');
   pm.add('/@re2:aaa|bbb/kkk', 'regexp3');
 
+  pm.add('/@twittername:@.*', 'regexp4');
+
+
   assertMatch(test, pm, '/one/', 'regexp1', {'re1': 'one'});
   assertMatch(test, pm, '/two/', 'regexp1', {'re1': 'two'});
   assertMatch(test, pm, '/three/', 'regexp1', {'re1': 'three'});
@@ -58,6 +61,8 @@ exports.testRegExpPathMatching = function(test) {
 
   assertMatch(test, pm, '/aaa/kkk/', 'regexp3', {'re2': 'aaa'});
   assertMatch(test, pm, '/bbb/kkk/', 'regexp3', {'re2': 'bbb'});
+
+  assertMatch(test, pm, '/@dpup', 'regexp4', {'twittername': '@dpup'});
 
   test.equals(null, pm.getMatch('/four/'));
 


### PR DESCRIPTION
Hello jeremy, 

Please review the following commits I made in branch 'pupius-pathmatcher'.

7730e6aafcef42c3a78f7fe72d96304688f85c4e (2012-10-02 14:59:03 -0700)
Add test to make sure regexp matches work

R=jeremy
