### PR TITLE
Strip fragments before passing URL to pathmatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "matador"
   , "description": "an MVC framework for Node"
-  , "version": "1.1.23-beta"
+  , "version": "1.1.24-beta"
   , "homepage": "https://github.com/Obvious/matador"
   , "main": "src/matador.js"
   , "authors": [

--- a/src/matador.js
+++ b/src/matador.js
@@ -340,8 +340,12 @@ module.exports.createApp = function (baseDir, configuration, options) {
       // check for any handler for the http method first
       if (!matcher) return next()
 
+      // Strip querystring and fragment.  Fragment should never be seen but we've seen it sent by
+      // scrapers and other tools (e.g. Kindle).
+      var url = req.url.replace(/[?#].*$/, '')
+
       // try and match
-      var handler = matcher.getMatch(req.url.split('?')[0])
+      var handler = matcher.getMatch(url)
       if (!handler) return next()
 
       // successful match, attach it to the req obj


### PR DESCRIPTION
Hello jeremy, 

Please review the following commits I made in branch 'dpup-fragment'.

e2043efbada915c7dccfd42b73938506b7eb114d (2013-04-02 16:54:15 -0700)
Strip fragments before passing URL to pathmatcher

R=jeremy
