### PR TITLE
usage text for cli tool, prevent overwriting

### DIFF
--- a/bin/matador.js
+++ b/bin/matador.js
@@ -11,10 +11,17 @@ var methods = {
     }
 
     console.log('installing Matador into ' + path)
-    fs.mkdirSync('./' + path)
-    exec('cp -R ' + __dirname + '/../src/all/ ' + path, function (err, out) {
-      if (err) return console.log('error', err)
-      console.log('Success!')
+
+    fs.exists(path, function (exists) {
+      if (exists) {
+        console.log(path + " already exists")
+      } else {
+        fs.mkdirSync('./' + path)
+        exec('cp -R ' + __dirname + '/../src/all/ ' + path, function (err, out) {
+          if (err) return console.log('error', err)
+          console.log('Success!')
+        })
+      }
     })
   }
 , controller: function (name) {
@@ -39,8 +46,15 @@ var methods = {
       }) + 'Controller.js'
       console.log('generating controller ' + destinationFile)
       var stub = __dirname + '/../src/StubController.js'
-      exec('cp ' + stub + ' ' + destinationFile, function (er, out) {
-        console.log('Successfully created ' + destinationFile)
+
+      fs.exists(destinationFile, function(exists) {
+        if (exists) {
+          console.log(destinationFile + " already exists")
+        } else {
+          exec('cp ' + stub + ' ' + destinationFile, function (er, out) {
+            console.log('Successfully created ' + destinationFile)
+          })
+        }
       })
     }
   }
@@ -56,8 +70,15 @@ var methods = {
       return l.toUpperCase()
     }) + 'Model.js'
     var stub = __dirname + '/../src/StubModel.js'
-    exec('cp ' + stub + ' ' + destinationFile, function (er, out) {
-      console.log('Successfully created ' + destinationFile)
+
+    fs.exists(destinationFile, function(exists) {
+      if (exists) {
+        console.log(destinationFile + " already exists")
+      } else {
+        exec('cp ' + stub + ' ' + destinationFile, function (er, out) {
+          console.log('Successfully created ' + destinationFile)
+        })
+      }
     })
   }
 , help: function () {


### PR DESCRIPTION
Adding a new command to the `matador` tool, `help`. It shows usage for the tool.

Generating with `matador init/controller/model` will tell you if the files to be written will overwrite anything and stops execution there. If you want them overwritten, delete the originals.
