### PR TITLE
Add basic package.json and .gitignore files to the base Matador install

### DIFF
--- a/src/all/.gitignore
+++ b/src/all/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/all/package.json
+++ b/src/all/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "matador-application",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "matador": "*"
+  }
+}


### PR DESCRIPTION
I recommend adding these files to the base matador install to assist quicker bootstrapping of new projects; a package.json file will allow simply running `npm install` in the newly created app directly, and git usage is very high with npm users, so it's safe to assume new users will (or should) be using git. These are really simple additions, but it should reduce the barrier to entry just slightly.
