### PR TITLE
Export PathMatcher

### DIFF
--- a/src/matador.js
+++ b/src/matador.js
@@ -9,6 +9,7 @@ var fs = require('fs')
   , CacheHelper = require('./helpers/CacheHelper')
   , FileLoader = require('./FileLoader')
   , ClassLoader = require('./ClassLoader')
+  , PathMatcher = require('./PathMatcher')
   , isDirectory = fsutils.isDirectory
 
 // DEPRECATED: Some old apps rely on argv being parsed by
@@ -448,6 +449,9 @@ module.exports.createApp = function (baseDir, configuration, options) {
 
   return app
 }
+
+// Export Matador's path matcher for potential client-side use
+module.exports.PathMatcher = PathMatcher
 
 /**
  * DEPRECATED: Old apps may still load CacheHelper manually.

--- a/tests/unit/PathMatcher_test.js
+++ b/tests/unit/PathMatcher_test.js
@@ -1,4 +1,4 @@
-var PathMatcher = require('../../src/pathmatcher');
+var PathMatcher = require('../../src/matador').PathMatcher;
 
 exports.testPathMatcher = function (test) {
   var pm = new PathMatcher();


### PR DESCRIPTION
Hello @vinibaggio, 

This is to better facilitate Obvious/medium2#6180, so we can use Matador's path matching on the frontend and not have inconsistencies.

Should I update the `package.json` version with this change?

Please review the following commits I made in branch 'kylehardgrave-export-pathmatcher'.

76b7863a86c5fa732563706b53ed28ac8c473a9b (2013-06-25 16:57:28 -0700)
Export PathMatcher

R=@vinibaggio
