### PR TITLE
Improved return type of PathMatcher.getMatch

### DIFF
--- a/src/pathMatcher.js
+++ b/src/pathMatcher.js
@@ -91,7 +91,8 @@ PathMatcher.prototype.add = function (path, object) {
 /**
  * Gets the matching node for the given path.  If no path matches, then null.
  * @param {string} path The path to match.
- * @return {Object} An object corresponding to the matched path.
+ * @return {?{object: Object, matches: Object.<string>}} An object
+ *     corresponding to the matched path.
  */
 PathMatcher.prototype.getMatch = function (path) {
   var parts = this.getPathParts_(path)


### PR DESCRIPTION
Hello @nicks, 

Needed so Obvious/medium2#6272 will type-check. Also more accurate.

Please review the following commits I made in branch 'kylehardgrave-fix-getmatch-type'.

4981e70e369a6dfc93678beed53eda2dd7e05f5f (2013-06-28 12:34:42 -0700)
Improved return type of PathMatcher.getMatch

R=@nicks
VISIBLE_CHANGES=Changed type signature of PathMatcher.getMatch
