### PR TITLE
fixed call to 'classLoader.loadClass' in 'app.getModel'

### DIFF
--- a/src/matador.js
+++ b/src/matador.js
@@ -363,7 +363,7 @@ module.exports.createApp = function (baseDir, configuration, options) {
    * @return {Object} a model class or instance
    */
   app.getModel = function (name, definitionOnly) {
-    return loadClass(paths.MODELS, name + filenameSuffixes.MODELS, name, definitionOnly)
+    return classLoader.loadClass(paths.MODELS, name + filenameSuffixes.MODELS, name, definitionOnly)
   }
 
   /**


### PR DESCRIPTION
Matador crashes with the error message "ReferenceError: loadClass is not defined".  Adding a reference to the appropriate class fixes the issue.
