### PR TITLE
Tiny boot() refactor

### DIFF
--- a/src/matador.js
+++ b/src/matador.js
@@ -473,7 +473,7 @@ module.exports.createApp = function (baseDir, configuration, options) {
     }
   }
 
-  app.boot = function (afterBootCallback) {
+  app.boot = function () {
     app.addPublicStaticRoutes()
 
     // Register the matador cache helper.
@@ -504,9 +504,7 @@ module.exports.createApp = function (baseDir, configuration, options) {
       app.use(connect.errorHandler())
     })
 
-    if (afterBootCallback) {
-      afterBootCallback()
-    }
+    app.emit('afterBoot')
 
     app.use(app.router({}))
     app.prefetch()

--- a/tests/functional/boot_callback_test.js
+++ b/tests/functional/boot_callback_test.js
@@ -9,12 +9,14 @@ exports.testAfterBootCallbackRuns = function (test) {
   var app = matador.createApp(__dirname, {}, {})
     , spy = false
 
-  app.boot(function () {
+  app.on('afterBoot', function () {
     app.use(function (req, res, next) {
       spy = true
       next()
     })
   })
+
+  app.boot()
 
   app.request()
   .get('/')


### PR DESCRIPTION
Hello anyone, 

Please review the following commits I made in branch 'vinny-boot-refactor'.

c7f36e9bfa0fbb31dc1d9e81c9f4db4653bcdaa5 (2013-09-06 11:17:47 -0300)
Remove session from boot so secret is not hardcoded

851406f9d1ed3496334435fb3eb0e6d946d2e5b9 (2013-09-06 11:17:29 -0300)
Calling afterboot callback after boot is done but before router

R=anyone
