### PR TITLE
remove extraneous call to decodeURI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "matador",
   "description": "an MVC framework for Node",
-  "version": "2.0.0-alpha.13",
+  "version": "2.0.0-alpha.14",
   "homepage": "https://github.com/Medium/matador",
   "main": "src/matador.js",
   "authors": [

--- a/src/matador.js
+++ b/src/matador.js
@@ -483,12 +483,7 @@ function preRouter(app, req, res, next) {
   req.params = {}
   if (handler.matches) {
     for (var key in handler.matches) {
-      if (key == '*' && Array.isArray(handler.matches['*'])) {
-        // The wildcard param passes an array of path parts.
-        req.params['*'] = handler.matches['*'].map(decodeURI)
-      } else {
-        req.params[key] = decodeURI(handler.matches[key])
-      }
+      req.params[key] = handler.matches[key]
     }
   }
   return next()

--- a/tests/functional/app/config/routes.js
+++ b/tests/functional/app/config/routes.js
@@ -1,5 +1,7 @@
 module.exports = function (app) {
   return {
-    '/': 'Home.index'
+    '/': 'Home.index',
+    '/wildcard/*': 'Home.wildcard',
+    '/name/:name': 'Home.name'
   }
 }

--- a/tests/functional/app/controllers/HomeController.js
+++ b/tests/functional/app/controllers/HomeController.js
@@ -11,6 +11,14 @@ module.exports = function (app, config) {
     return res.send('hello')
   }
 
+  HomeController.prototype.wildcard = function(req, res) {
+    var matched = req.params['*'] || []
+    return res.send(matched.join(', '))
+  }
+
+  HomeController.prototype.name = function(req, res) {
+    return res.send(req.params['name'] || '')
+  }
 
   return HomeController
 }

--- a/tests/functional/routing_test.js
+++ b/tests/functional/routing_test.js
@@ -1,0 +1,62 @@
+// Copyright 2016. A Medium Corporation
+
+var request = require('../support/functional')
+
+var matador = require('../../src/matador')
+  , RequestMessage = require('../../src/RequestMessage')
+
+exports.testNamedParameterEscaping = function (test) {
+  var app = matador.createApp(__dirname, {})
+  app.useCommonMiddleware()
+  app.start()
+
+  request(app)
+  .get('/name/' + encodeURIComponent('hello%20world'))
+  .end(function (res) {
+    test.equal(200, res.statusCode)
+    test.equal('hello%20world', res.body)
+    test.done()
+  })
+}
+
+exports.testWildcardEscapedUrl = function (test) {
+  var app = matador.createApp(__dirname, {})
+  app.useCommonMiddleware()
+  app.start()
+
+  request(app)
+  .get('/wildcard/' + encodeURIComponent('http://example.com/abc%5E123'))
+  .end(function (res) {
+    test.equal(200, res.statusCode)
+    test.equal('http://example.com/abc%5E123', res.body)
+    test.done()
+  })
+}
+
+exports.testWildcardUnescapedUrl = function (test) {
+  var app = matador.createApp(__dirname, {})
+  app.useCommonMiddleware()
+  app.start()
+
+  request(app)
+  .get('/wildcard/example.com/foo%3Fbar%3Dbaz')
+  .end(function (res) {
+    test.equal(200, res.statusCode)
+    test.equal('example.com, foo?bar=baz', res.body)
+    test.done()
+  })
+}
+
+exports.testWildcardMatchingPath = function (test) {
+  var app = matador.createApp(__dirname, {})
+  app.useCommonMiddleware()
+  app.start()
+
+  request(app)
+  .get('/wildcard/a/b%255Ec/d/e')
+  .end(function (res) {
+    test.equal(200, res.statusCode)
+    test.equal('a, b%5Ec, d, e', res.body)
+    test.done()
+  })
+}

--- a/tests/unit/PathMatcher_test.js
+++ b/tests/unit/PathMatcher_test.js
@@ -33,6 +33,7 @@ exports.testPathMatcher = function (test) {
   assertMatch(test, pm, '/%EB%82%98%EB%8A%94%EC%9D%B4-%EC%A0%9C%EB%AA%A9%EC%9D%B4-%EC%82%AC%EC%8B%A4-%EB%A1%9C-%EB%B2%88%EC%97%AD-%EB%AC%B4%EC%97%87%EC%9D%B8%EC%A7%80-%EC%A0%84%ED%98%80-%EB%AA%A8%EB%A5%B8%EB%8B%A4/', 'user', {user: '나는이-제목이-사실-로-번역-무엇인지-전혀-모른다'});
 
   assertMatch(test, pm, '/dir/abc', 'dir', {'*': ['abc']});
+  assertMatch(test, pm, '/dir/http%3A%2F%2Fexample.com%2Fabc%255E123', 'dir', {'*': ['http://example.com/abc%5E123']})
 
   // No wildcards.
   test.equals(null, pm.getMatch('/about/what/'));


### PR DESCRIPTION
Hello @adrianlee44, @majelbstoat, @nicks, 

Please review the following commits I made in branch 'kylewm/over-decoding'.

3868ba6b90c9f455bdbc15b6c473808505113978 (2016-06-23 13:28:30 -0700)
remove extraneous call to decodeURI

- calling decodeURI twice makes it difficult to pass in encoded special characters
  intact
- add functional tests for over-decoding paths matching *

R=@adrianlee44
R=@majelbstoat 
R=@nicks