### PR TITLE
Turn autoescape contextual to the deprecated property

### DIFF
--- a/src/all/app/views/layout.soy
+++ b/src/all/app/views/layout.soy
@@ -5,7 +5,7 @@
  * Renders the index page.
  * @param title Title of the page.
  */
-{template .layout autoescape="contextual"}
+{template .layout autoescape="deprecated-contextual"}
   <!DOCTYPE html>
   <html>
     <head>


### PR DESCRIPTION
Provisional solution, using deprecated property. Need to find an other way to fix the issue.